### PR TITLE
issue #5 - add capability to forward request data

### DIFF
--- a/src/main/java/io/proximax/dfms/http/MultipartRequestContent.java
+++ b/src/main/java/io/proximax/dfms/http/MultipartRequestContent.java
@@ -62,15 +62,6 @@ public class MultipartRequestContent extends RequestBody {
       this.contentType = MediaType.get("multipart/form-data; boundary=" + boundary);
    }
 
-   /**
-    * create new instance with random boundary
-    * 
-    * @param content the drive content used to create request body
-    */
-   public MultipartRequestContent(DriveContent content) {
-      this(content, createBoundary());
-   }
-
    @Override
    public MediaType contentType() {
       return contentType;
@@ -99,7 +90,7 @@ public class MultipartRequestContent extends RequestBody {
     * 
     * @return boundary string
     */
-   private static String createBoundary() {
+   public static String createBoundary() {
       final int numChars = BOUNDARY_CHARS.length();
       final StringBuilder b = new StringBuilder();
       for (int i = 0; i < BOUNDARY_SIZE; i++) {

--- a/src/main/java/io/proximax/dfms/http/RawMultipartRequestContent.java
+++ b/src/main/java/io/proximax/dfms/http/RawMultipartRequestContent.java
@@ -1,0 +1,51 @@
+/**
+ * 
+ */
+package io.proximax.dfms.http;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import okhttp3.MediaType;
+import okhttp3.RequestBody;
+import okio.BufferedSink;
+
+/**
+ * request body implementation used to simply forward existing form multipart request body serialized to input stream
+ */
+public class RawMultipartRequestContent extends RequestBody {
+
+   private final MediaType contentType;
+   private final InputStream is;
+   
+   /**
+    * create new request body
+    * 
+    * @param contentType content type including the boundary
+    * @param is input stream with the data
+    */
+   public RawMultipartRequestContent(MediaType contentType, InputStream is) {
+      this.contentType = contentType;
+      this.is = is;
+   }
+
+   @Override
+   public MediaType contentType() {
+      return contentType;
+   }
+
+   @Override
+   public void writeTo(BufferedSink sink) throws IOException {
+      byte[] buffer = new byte[4096];
+      int r;
+      while ((r = is.read(buffer)) != -1) {
+         sink.write(buffer, 0, r);
+      }
+   }
+
+   @Override
+   public boolean isOneShot() {
+      // return true to indicate that it is not possible to replay the serialization
+      return true;
+   }
+}

--- a/src/main/java/io/proximax/dfms/model/drive/content/RawInputStreamContent.java
+++ b/src/main/java/io/proximax/dfms/model/drive/content/RawInputStreamContent.java
@@ -1,0 +1,36 @@
+/**
+ * 
+ */
+package io.proximax.dfms.model.drive.content;
+
+import java.io.InputStream;
+import java.util.Optional;
+
+import okhttp3.MediaType;
+
+/**
+ * raw content implementation simply forwarding content of input stream
+ */
+public class RawInputStreamContent extends InputStreamContent {
+
+   private final MediaType contentType;
+   
+   /**
+    * create new content
+    * 
+    * @param name arbitrary name of the content
+    * @param inputStream input stream containing request body
+    * @param contentType content type of data in the input stream
+    */
+   public RawInputStreamContent(Optional<String> name, InputStream inputStream, MediaType contentType) {
+      super(name, inputStream);
+      this.contentType = contentType;
+   }
+
+   /**
+    * @return the contentType
+    */
+   public MediaType getContentType() {
+      return contentType;
+   }
+}

--- a/src/test/java/io/proximax/dfms/http/MultipartRequestContentTest.java
+++ b/src/test/java/io/proximax/dfms/http/MultipartRequestContentTest.java
@@ -24,7 +24,7 @@ import okhttp3.RequestBody;
 import okio.Buffer;
 
 /**
- * TODO add proper description
+ * {@link MultipartRequestContent} tests
  */
 class MultipartRequestContentTest {
 
@@ -53,15 +53,15 @@ class MultipartRequestContentTest {
    @Test
    void testBoundaryGenerator() {
       DriveContent content = new FileSystemContent(Paths.get(".", "src", "test", "resources", "simple", "text1.txt"));
-      MultipartRequestContent body1 = new MultipartRequestContent(content);
-      MultipartRequestContent body2 = new MultipartRequestContent(content);
+      MultipartRequestContent body1 = new MultipartRequestContent(content, MultipartRequestContent.createBoundary());
+      MultipartRequestContent body2 = new MultipartRequestContent(content, MultipartRequestContent.createBoundary());
       assertNotEquals(body1.getBoundary(), body2.getBoundary());
    }
    
    @Test
    void testContentType() {
       DriveContent content = new FileSystemContent(Paths.get(".", "src", "test", "resources", "simple", "text1.txt"));
-      MultipartRequestContent body = new MultipartRequestContent(content);
+      MultipartRequestContent body = new MultipartRequestContent(content, MultipartRequestContent.createBoundary());
       assertTrue(body.contentType().toString().contains(body.getBoundary()));
    }
    

--- a/src/test/java/io/proximax/dfms/http/repos/DriveHttpTest.java
+++ b/src/test/java/io/proximax/dfms/http/repos/DriveHttpTest.java
@@ -1,0 +1,41 @@
+/**
+ * 
+ */
+package io.proximax.dfms.http.repos;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.io.ByteArrayInputStream;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+
+import io.proximax.dfms.http.MultipartRequestContent;
+import io.proximax.dfms.http.RawMultipartRequestContent;
+import io.proximax.dfms.model.drive.DriveContent;
+import io.proximax.dfms.model.drive.content.RawInputStreamContent;
+import okhttp3.MediaType;
+import okhttp3.RequestBody;
+
+/**
+ * {@link DriveHttp} tests
+ */
+class DriveHttpTest {
+
+   @Test
+   void testStandardContentFactory() {
+      DriveContent content = DriveContent.from(Optional.of("hello"), new byte[] { 1, 2, 3 });
+      RequestBody body = DriveHttp.createRequestBody(content);
+      assertTrue(body instanceof MultipartRequestContent);
+   }
+
+   @Test
+   void testRawContentFactory() {
+      DriveContent content = new RawInputStreamContent(Optional.of("hello"),
+            new ByteArrayInputStream(new byte[] { 1, 2, 3 }),
+            MediaType.get("multipart/form-data; boundary=" + MultipartRequestContent.createBoundary()));
+      RequestBody body = DriveHttp.createRequestBody(content);
+      assertTrue(body instanceof RawMultipartRequestContent);
+   }
+
+}


### PR DESCRIPTION
when caller already has serialized request body and it is desirable only to forward it as part of API request then RawInputStreamContent can be used

This is needed to efficiently forward request between incoming and outgoing API